### PR TITLE
Alternative Flag attributes implementation

### DIFF
--- a/src/lib/lit-extended.ts
+++ b/src/lib/lit-extended.ts
@@ -58,7 +58,7 @@ export const extendedPartCallback =
             }
             if (templatePart.name!.endsWith('$')) {
               const name = templatePart.name!.slice(0, -1);
-              return new AttributePart(
+              return new ExtendedAttributePart(
                   instance, node as Element, name, templatePart.strings!);
             }
             return new PropertyPart(
@@ -69,6 +69,23 @@ export const extendedPartCallback =
           }
           return defaultPartCallback(instance, templatePart, node);
         };
+
+export class ExtendedAttributePart extends AttributePart {
+    setValue(values: any[], startIndex: number): void {
+        const s = this.strings;
+        if (s.length == 2 && s[0] == "" && s[1] == "") {
+            const v = values[startIndex];
+            if (v === false || v === null || v === undefined) {
+                this.element.removeAttribute(this.name);
+                return;
+            } else if (v === true) {
+                this.element.setAttribute(this.name, "");
+                return;
+            }
+        } 
+        super.setValue(values, startIndex);
+    }
+}
 
 export class PropertyPart extends AttributePart {
   setValue(values: any[], startIndex: number): void {

--- a/src/test/lib/lit-extended_test.ts
+++ b/src/test/lib/lit-extended_test.ts
@@ -50,6 +50,35 @@ suite('lit-extended', () => {
       render(html`<div foo$="1${'bar'}2${'baz'}3"></div>`, container);
       assert.equal(container.innerHTML, '<div foo="1bar2baz3"></div>');
     });
+    
+   test('renders flag attribute for true', () => {
+      render(html`<div foo$="${true}"></div>`, container);
+      assert.equal(container.innerHTML, '<div foo=""></div>');
+   });
+   test('renders flag attribute for empty string', () => {
+      render(html`<div foo$="${''}"></div>`, container);
+      assert.equal(container.innerHTML, '<div foo=""></div>');
+   });
+   test('does not render flag attribute for false', () => {
+     render(html`<div foo$="${false}"></div>`, container);
+     assert.equal(container.innerHTML, '<div></div>');
+   });
+   test('does not render flag attribute for null', () => {
+     render(html`<div foo$="${null}"></div>`, container);
+     assert.equal(container.innerHTML, '<div></div>');
+   });
+   test('does not render flag attribute for undefined', () => {
+     render(html`<div foo$="${undefined}"></div>`, container);
+     assert.equal(container.innerHTML, '<div></div>');
+   });
+   test('renders attribute with string true', () => {
+     render(html`<div foo$="${'true'}"></div>`, container);
+     assert.equal(container.innerHTML, '<div foo="true"></div>');
+   });
+   test('renders attribute with string false', () => {
+     render(html`<div foo$="${'false'}"></div>`, container);
+     assert.equal(container.innerHTML, '<div foo="false"></div>');
+   });
 
     test('reuses an existing ExtendedTemplateInstance when available', () => {
       const t = (content: any) => html`<div>${content}</div>`;


### PR DESCRIPTION
Alternative implementation to #197 for lit-extended attributes with following differences:
1.  it treats null and undefined as false - this behavior is consistent with polymer: unresolved/uninitialized expressions will not set (e.g. hidden)
2.  no special syntax other than $= required. In rare case that you actually want to set attribute as "true" or "false", just use a ? "true" : "false"

```html
<div hidden$="${true}"/>  => <div hidden=""/>
<div hidden$="${false}"/> => <div />
<div hidden$="${null}"/> => <div />
<div hidden$="${undefined}"/> => <div />
<div hidden$="${!(undefined)}"/> => <div hidden="" />
<div hidden$="${'true'}"/>  => <div hidden="true"/>
<div hidden$="${'false'}"/>  => <div hidden="false"/>
```